### PR TITLE
Use `uname -m` for `make` 64bit compatibility check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ NERVES_BR_DL_DIR ?= $(HOME)/.nerves/cache/buildroot
 ifneq ($(shell uname -s),Linux)
 $(error Nerves system images can only be built using Linux)
 endif
-ifneq ($(shell uname -p),x86_64)
+ifneq ($(shell uname -m),x86_64)
 $(error 64-bit Linux required for supported cross-compilers)
 endif
 


### PR DESCRIPTION
It seems the output of `uname -p` (processor) is not as consistent for
returning "x86_64" as `uname -m` on multiple platforms.

On an Arch Linux system, `-p` returns "unknown" whilst `-m` correctly
returns "x86_64`.

On a 2009 MacBook Pro (64bit Core 2 Duo) running El Capitan `-p` returns
"i386" and `-m` again returns "x86_64".

Both `-p` and `-m` returns "x86_64" on tests boxes of Ubuntu Wiley,
Scientific Linux and Fedora.