### PR TITLE
Change erlang inet configuration to use the inet_res resolver.

### DIFF
--- a/board/nerves-common/rootfs-additions/etc/erl_inetrc
+++ b/board/nerves-common/rootfs-additions/etc/erl_inetrc
@@ -1,0 +1,9 @@
+%% -- ERLANG INET CONFIGURATION FILE --
+%% read the hosts file
+{file, hosts, "/etc/hosts"}.
+%% monitor the hosts file
+{hosts_file, "/etc/hosts"}.
+%% read and monitor nameserver config from here
+{resolv_conf, "/etc/resolv.conf"}.
+%% specify lookup method
+{lookup, [file, dns, native]}.

--- a/package/nerves-config/erlinit.config.m4
+++ b/package/nerves-config/erlinit.config.m4
@@ -18,8 +18,8 @@ ifelse(VERBOSE_INIT, `y', `-v', `#-v')
 # Uncomment to hang the board rather than rebooting when Erlang exits
 ifelse(HANG_ON_EXIT, `y', `-h', `#-h')
 
-# Enable UTF-8 filename handling in Erlang
--e LANG=en_US.UTF-8;LANGUAGE=en
+# Enable UTF-8 filename handling in Erlang and custom inet configuration
+-e LANG=en_US.UTF-8;LANGUAGE=en;ERL_INETRC=/etc/erl_inetrc
 
 # Mount the application partition
 # See http://www.linuxfromscratch.org/lfs/view/6.3/chapter08/fstab.html about


### PR DESCRIPTION
This is going to require the addition of ERL_INETRC=/etc/erl_inetrc to other targets. This is a proposition, I have found that the `inet_res` resolver operates better on nerves than the native resolver. This fixes issues with distributed erlang