### PR TITLE
Use -R when copying files

### DIFF
--- a/scripts/rel2fw.sh
+++ b/scripts/rel2fw.sh
@@ -75,7 +75,7 @@ mkdir -p $TMP_DIR/rootfs-additions
 
 # Construct the proper path for the Erlang/OTP release
 mkdir -p $TMP_DIR/rootfs-additions/srv/erlang
-cp -r $RELEASE_DIR/* $TMP_DIR/rootfs-additions/srv/erlang
+cp -R $RELEASE_DIR/* $TMP_DIR/rootfs-additions/srv/erlang
 
 # Clean up the Erlang release of all the files that we don't need.
 $NERVES_SYSTEM/scripts/scrub-otp-release.sh $TMP_DIR/rootfs-additions/srv/erlang


### PR DESCRIPTION
Using `-r` results in `bake firmware` stuck at `Updating base firmware image with Erlang release...` step:

```
...
==> The release for helloworld-0.0.1 has been removed.
Building release with MIX_ENV=dev.
==> Modifying release for Nerves System rpi2-0.4.0-rc1
==> The release for helloworld-0.0.1 is ready!
==> You can boot a console running your release with `$ rel/helloworld/bin/helloworld console`
Updating base firmware image with Erlang release...
```

After investigation, it looked like `cp` command froze while trying to copy pipes from this folder:

```
gmile@Eugenes-MacBook-Pro-2 ~/p/n/helloworld> ls -lat rel/helloworld/tmp/erl_pipes/helloworld
total 0
prw-r--r--  1 gmile  staff    0 Mar  5 13:40 erlang.pipe.1.r
prw-r--r--  1 gmile  staff    0 Mar  5 13:40 erlang.pipe.1.w
drwxr-xr-x  4 gmile  staff  136 Mar  5 13:40 .
drwxr-xr-x  3 gmile  staff  102 Mar  5 13:39 ..
```

It appears that `-r` results in `cp` trying to read from pipe, not perform a copy. Also, it looks like `-R` is [encouraged](http://unix.stackexchange.com/a/18718/30894) over `-r`.